### PR TITLE
Add simple frontend and API routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+/.idea/
+.DS_Store
+/data/

--- a/MVP_FEATURES.md
+++ b/MVP_FEATURES.md
@@ -1,0 +1,17 @@
+# MVP Feature Set
+
+1. **User Registration and Authentication** (PHP) – allow job seekers and recruiters to create accounts and log in.
+2. **Job Posting & Search** (PHP) – recruiters can create job listings; job seekers can browse and search.
+3. **Simple Job Matching** (Python Service) – initial keyword/skills matching API.
+4. **Application Tracking** (PHP) – track job applications and statuses.
+5. **Document Upload** (PHP) – CV/resume storage for job seekers.
+6. **Basic Messaging** (PHP) – direct messages between seekers and recruiters.
+7. **Foundational Database Schema** – tables for users, jobs, applications, and messages.
+
+## Implemented So Far
+- Basic SQLite database with tables for users, jobs, and applications
+- Endpoint for user registration
+- Endpoints for creating and listing jobs
+- Endpoints for applying to jobs and listing applications
+- Document upload endpoint and documents table
+- Basic messaging endpoints and messages table

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# PHP
+# PHP Backend
+
+This repository contains the PHP portion of a Python/PHP job matching application for job seekers and recruiters. It handles user authentication, job postings, messaging, and communicates with Python-based AI services.
+
+## Getting Started
+
+Install dependencies with [Composer](https://getcomposer.org/):
+
+```bash
+composer install
+```
+
+Run the database migration to create the SQLite database:
+
+```bash
+php scripts/migrate.php
+```
+
+Run the development server:
+
+```bash
+php -S localhost:8000 -t public
+```
+
+### API Endpoints
+
+- `POST /register` – create a new user (`name`, `email`, `role`)
+- `POST /jobs` – create a job posting (`title`, `description`, `requiredSkills`)
+- `GET /jobs` – list jobs
+- `POST /apply` – apply to a job (`user_id`, `job_id`)
+- `GET /applications` – list applications
+- `POST /documents` – upload a CV/resume (`file`, `user_id`)
+- `GET /documents?user_id={id}` – list uploaded documents
+- `POST /messages` – send a message (`sender_id`, `receiver_id`, `content`)
+- `GET /messages?user_id={id}` – list messages for a user
+
+Visit `http://localhost:8000` in your browser to use the web interface. The forms on this page
+interact with the API endpoints described above.
+
+### Frontend
+
+A simple HTML frontend lives in `public/index.html` with accompanying CSS and JavaScript
+in `public/assets/`. It provides forms for registration, job management, applications and
+messaging. The design uses a dark theme with bright accents for a modern look.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "job-matching/app",
+    "description": "PHP backend for the job matching platform",
+    "type": "project",
+    "require": {
+        "php": ">=7.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,20 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "073171e1f8260ec735b097c7455f6477",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.4"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/config/database.php
+++ b/config/database.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'dsn' => 'sqlite:' . __DIR__ . '/../data/database.sqlite',
+    'username' => null,
+    'password' => null,
+];

--- a/public/assets/app.js
+++ b/public/assets/app.js
@@ -1,0 +1,79 @@
+document.querySelectorAll('nav button').forEach(btn => {
+    btn.addEventListener('click', () => {
+        document.querySelectorAll('main section').forEach(sec => sec.classList.remove('active'));
+        document.getElementById(btn.dataset.section).classList.add('active');
+    });
+});
+
+const api = path => fetch(path, { headers: { 'Content-Type': 'application/json' } });
+
+// Register
+const registerForm = document.getElementById('register-form');
+registerForm.addEventListener('submit', async e => {
+    e.preventDefault();
+    const data = Object.fromEntries(new FormData(registerForm));
+    const res = await fetch('/register', { method: 'POST', body: JSON.stringify(data) });
+    const json = await res.json();
+    document.getElementById('register-response').textContent = JSON.stringify(json, null, 2);
+});
+
+// Post Job
+const jobForm = document.getElementById('job-form');
+jobForm.addEventListener('submit', async e => {
+    e.preventDefault();
+    const data = Object.fromEntries(new FormData(jobForm));
+    const res = await fetch('/jobs', { method: 'POST', body: JSON.stringify(data) });
+    const json = await res.json();
+    alert('Job created with ID ' + json.id);
+    jobForm.reset();
+});
+
+// Load Jobs
+const loadJobsBtn = document.getElementById('load-jobs');
+loadJobsBtn.addEventListener('click', async () => {
+    const res = await fetch('/jobs');
+    const jobs = await res.json();
+    const list = document.getElementById('job-list');
+    list.innerHTML = '';
+    jobs.forEach(job => {
+        const li = document.createElement('li');
+        li.textContent = `${job.id}: ${job.title}`;
+        list.appendChild(li);
+    });
+});
+
+// Apply
+const applyForm = document.getElementById('apply-form');
+applyForm.addEventListener('submit', async e => {
+    e.preventDefault();
+    const data = Object.fromEntries(new FormData(applyForm));
+    const res = await fetch('/apply', { method: 'POST', body: JSON.stringify(data) });
+    const json = await res.json();
+    document.getElementById('apply-response').textContent = JSON.stringify(json, null, 2);
+});
+
+// Send Message
+const messageForm = document.getElementById('message-form');
+messageForm.addEventListener('submit', async e => {
+    e.preventDefault();
+    const data = Object.fromEntries(new FormData(messageForm));
+    const res = await fetch('/messages', { method: 'POST', body: JSON.stringify(data) });
+    const json = await res.json();
+    alert('Message sent with ID ' + json.id);
+    messageForm.reset();
+});
+
+// Load Messages
+const loadMessagesBtn = document.getElementById('load-messages');
+loadMessagesBtn.addEventListener('click', async () => {
+    const userId = document.getElementById('inbox-user').value;
+    const res = await fetch('/messages?user_id=' + encodeURIComponent(userId));
+    const messages = await res.json();
+    const list = document.getElementById('message-list');
+    list.innerHTML = '';
+    messages.forEach(msg => {
+        const li = document.createElement('li');
+        li.textContent = `${msg.sender_id} -> ${msg.receiver_id}: ${msg.content}`;
+        list.appendChild(li);
+    });
+});

--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -1,0 +1,63 @@
+body {
+    font-family: Arial, Helvetica, sans-serif;
+    background: linear-gradient(135deg, #1d1d1d, #333);
+    color: #eee;
+    margin: 0;
+    padding: 0;
+}
+header {
+    background: #111;
+    padding: 1rem;
+    text-align: center;
+    color: #0ff;
+}
+nav button {
+    margin: 0.5rem;
+    padding: 0.5rem 1rem;
+    background: #0ff;
+    border: none;
+    color: #111;
+    cursor: pointer;
+    border-radius: 4px;
+}
+nav button:hover {
+    background: #0cc;
+}
+main {
+    padding: 2rem;
+}
+section {
+    display: none;
+    max-width: 600px;
+    margin: auto;
+}
+section.active {
+    display: block;
+}
+form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+input, textarea, select {
+    padding: 0.5rem;
+    border-radius: 4px;
+    border: none;
+}
+button[type="submit"] {
+    background: #0ff;
+    color: #111;
+    border: none;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    border-radius: 4px;
+}
+button[type="submit"]:hover {
+    background: #0cc;
+}
+pre.response {
+    background: #222;
+    padding: 1rem;
+    border-radius: 4px;
+    overflow: auto;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Job Matching App</title>
+    <link rel="stylesheet" href="assets/style.css" />
+</head>
+<body>
+    <header>
+        <h1>Job Matching Platform</h1>
+        <nav>
+            <button data-section="register">Register</button>
+            <button data-section="jobs">Jobs</button>
+            <button data-section="apply">Apply</button>
+            <button data-section="messages">Messages</button>
+        </nav>
+    </header>
+    <main>
+        <section id="register" class="active">
+            <h2>Create Account</h2>
+            <form id="register-form">
+                <input type="text" name="name" placeholder="Name" required />
+                <input type="email" name="email" placeholder="Email" required />
+                <select name="role">
+                    <option value="seeker">Job Seeker</option>
+                    <option value="recruiter">Recruiter</option>
+                </select>
+                <button type="submit">Register</button>
+            </form>
+            <pre class="response" id="register-response"></pre>
+        </section>
+        <section id="jobs">
+            <h2>Post a Job</h2>
+            <form id="job-form">
+                <input type="text" name="title" placeholder="Title" required />
+                <textarea name="description" placeholder="Description" required></textarea>
+                <input type="text" name="requiredSkills" placeholder="Skills" required />
+                <button type="submit">Create Job</button>
+            </form>
+            <h3>Available Jobs</h3>
+            <button id="load-jobs">Load Jobs</button>
+            <ul id="job-list"></ul>
+        </section>
+        <section id="apply">
+            <h2>Apply to a Job</h2>
+            <form id="apply-form">
+                <input type="number" name="user_id" placeholder="Your User ID" required />
+                <input type="number" name="job_id" placeholder="Job ID" required />
+                <button type="submit">Apply</button>
+            </form>
+            <pre class="response" id="apply-response"></pre>
+        </section>
+        <section id="messages">
+            <h2>Messages</h2>
+            <form id="message-form">
+                <input type="number" name="sender_id" placeholder="Sender ID" required />
+                <input type="number" name="receiver_id" placeholder="Receiver ID" required />
+                <textarea name="content" placeholder="Message" required></textarea>
+                <button type="submit">Send Message</button>
+            </form>
+            <h3>Inbox</h3>
+            <input type="number" id="inbox-user" placeholder="User ID" />
+            <button id="load-messages">Load Messages</button>
+            <ul id="message-list"></ul>
+        </section>
+    </main>
+    <script src="assets/app.js"></script>
+</body>
+</html>

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,59 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use App\Controllers\UserController;
+use App\Controllers\JobController;
+use App\Controllers\ApplicationController;
+use App\Controllers\DocumentController;
+use App\Controllers\MessageController;
+
+$uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+$method = $_SERVER['REQUEST_METHOD'];
+
+// Serve the HTML interface when visiting the root from a browser
+if ($method === 'GET' && ($uri === '/' || $uri === '/index.html')) {
+    $accept = $_SERVER['HTTP_ACCEPT'] ?? '';
+    if (str_contains($accept, 'text/html') && file_exists(__DIR__ . '/index.html')) {
+        header('Content-Type: text/html');
+        readfile(__DIR__ . '/index.html');
+        return;
+    }
+}
+
+header('Content-Type: application/json');
+
+switch (true) {
+    case $method === 'GET' && $uri === '/':
+        echo json_encode(['message' => 'Job Matching App API']);
+        break;
+    case $method === 'POST' && $uri === '/register':
+        UserController::register();
+        break;
+    case $method === 'POST' && $uri === '/jobs':
+        JobController::create();
+        break;
+    case $method === 'GET' && $uri === '/jobs':
+        JobController::list();
+        break;
+    case $method === 'POST' && $uri === '/apply':
+        ApplicationController::apply();
+        break;
+    case $method === 'GET' && $uri === '/applications':
+        ApplicationController::list();
+        break;
+    case $method === 'POST' && $uri === '/documents':
+        DocumentController::upload();
+        break;
+    case $method === 'GET' && $uri === '/documents':
+        DocumentController::list();
+        break;
+    case $method === 'POST' && $uri === '/messages':
+        MessageController::send();
+        break;
+    case $method === 'GET' && $uri === '/messages':
+        MessageController::list();
+        break;
+    default:
+        http_response_code(404);
+        echo json_encode(['error' => 'Not Found']);
+}

--- a/scripts/migrate.php
+++ b/scripts/migrate.php
@@ -1,0 +1,47 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use App\Database;
+
+$pdo = Database::getConnection();
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    email TEXT UNIQUE,
+    role TEXT
+);");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS jobs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT,
+    description TEXT,
+    requiredSkills TEXT
+);");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS applications (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER,
+    job_id INTEGER,
+    status TEXT,
+    FOREIGN KEY(user_id) REFERENCES users(id),
+    FOREIGN KEY(job_id) REFERENCES jobs(id)
+);");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS documents (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER,
+    path TEXT,
+    FOREIGN KEY(user_id) REFERENCES users(id)
+);");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sender_id INTEGER,
+    receiver_id INTEGER,
+    content TEXT,
+    FOREIGN KEY(sender_id) REFERENCES users(id),
+    FOREIGN KEY(receiver_id) REFERENCES users(id)
+);");
+
+echo "Migration completed\n";

--- a/src/Controllers/ApplicationController.php
+++ b/src/Controllers/ApplicationController.php
@@ -1,0 +1,33 @@
+<?php
+namespace App\Controllers;
+
+use App\Database;
+
+use PDO;
+class ApplicationController
+{
+    public static function apply(): void
+    {
+        $data = json_decode(file_get_contents('php://input'), true);
+        if (!isset($data['user_id'], $data['job_id'])) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Invalid input']);
+            return;
+        }
+        $pdo = Database::getConnection();
+        $stmt = $pdo->prepare('INSERT INTO applications (user_id, job_id, status) VALUES (:user_id, :job_id, :status)');
+        $stmt->execute([
+            ':user_id' => $data['user_id'],
+            ':job_id' => $data['job_id'],
+            ':status' => 'applied',
+        ]);
+        echo json_encode(['id' => $pdo->lastInsertId()]);
+    }
+
+    public static function list(): void
+    {
+        $pdo = Database::getConnection();
+        $stmt = $pdo->query('SELECT * FROM applications');
+        echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));
+    }
+}

--- a/src/Controllers/DocumentController.php
+++ b/src/Controllers/DocumentController.php
@@ -1,0 +1,49 @@
+<?php
+namespace App\Controllers;
+
+class DocumentController
+{
+    public static function upload(): void
+    {
+        if (!isset($_FILES['file'], $_POST['user_id'])) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Invalid input']);
+            return;
+        }
+
+        $uploadDir = __DIR__ . '/../../data/uploads';
+        if (!is_dir($uploadDir)) {
+            mkdir($uploadDir, 0777, true);
+        }
+
+        $filename = basename($_FILES['file']['name']);
+        $targetPath = $uploadDir . '/' . uniqid() . '_' . $filename;
+        if (!move_uploaded_file($_FILES['file']['tmp_name'], $targetPath)) {
+            http_response_code(500);
+            echo json_encode(['error' => 'Failed to save file']);
+            return;
+        }
+
+        $pdo = \App\Database::getConnection();
+        $stmt = $pdo->prepare('INSERT INTO documents (user_id, path) VALUES (:user_id, :path)');
+        $stmt->execute([
+            ':user_id' => $_POST['user_id'],
+            ':path' => $targetPath,
+        ]);
+
+        echo json_encode(['id' => $pdo->lastInsertId()]);
+    }
+
+    public static function list(): void
+    {
+        if (!isset($_GET['user_id'])) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Missing user_id']);
+            return;
+        }
+        $pdo = \App\Database::getConnection();
+        $stmt = $pdo->prepare('SELECT id, path FROM documents WHERE user_id = :user_id');
+        $stmt->execute([':user_id' => $_GET['user_id']]);
+        echo json_encode($stmt->fetchAll(\PDO::FETCH_ASSOC));
+    }
+}

--- a/src/Controllers/JobController.php
+++ b/src/Controllers/JobController.php
@@ -1,0 +1,33 @@
+<?php
+namespace App\Controllers;
+
+use App\Database;
+
+use PDO;
+class JobController
+{
+    public static function create(): void
+    {
+        $data = json_decode(file_get_contents('php://input'), true);
+        if (!isset($data['title'], $data['description'], $data['requiredSkills'])) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Invalid input']);
+            return;
+        }
+        $pdo = Database::getConnection();
+        $stmt = $pdo->prepare('INSERT INTO jobs (title, description, requiredSkills) VALUES (:title, :description, :requiredSkills)');
+        $stmt->execute([
+            ':title' => $data['title'],
+            ':description' => $data['description'],
+            ':requiredSkills' => $data['requiredSkills'],
+        ]);
+        echo json_encode(['id' => $pdo->lastInsertId()]);
+    }
+
+    public static function list(): void
+    {
+        $pdo = Database::getConnection();
+        $stmt = $pdo->query('SELECT * FROM jobs');
+        echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));
+    }
+}

--- a/src/Controllers/MessageController.php
+++ b/src/Controllers/MessageController.php
@@ -1,0 +1,39 @@
+<?php
+namespace App\Controllers;
+
+use App\Database;
+use PDO;
+
+class MessageController
+{
+    public static function send(): void
+    {
+        $data = json_decode(file_get_contents('php://input'), true);
+        if (!isset($data['sender_id'], $data['receiver_id'], $data['content'])) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Invalid input']);
+            return;
+        }
+        $pdo = Database::getConnection();
+        $stmt = $pdo->prepare('INSERT INTO messages (sender_id, receiver_id, content) VALUES (:sender_id, :receiver_id, :content)');
+        $stmt->execute([
+            ':sender_id' => $data['sender_id'],
+            ':receiver_id' => $data['receiver_id'],
+            ':content' => $data['content'],
+        ]);
+        echo json_encode(['id' => $pdo->lastInsertId()]);
+    }
+
+    public static function list(): void
+    {
+        if (!isset($_GET['user_id'])) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Missing user_id']);
+            return;
+        }
+        $pdo = Database::getConnection();
+        $stmt = $pdo->prepare('SELECT * FROM messages WHERE sender_id = :id OR receiver_id = :id ORDER BY id DESC');
+        $stmt->execute([':id' => $_GET['user_id']]);
+        echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));
+    }
+}

--- a/src/Controllers/UserController.php
+++ b/src/Controllers/UserController.php
@@ -1,0 +1,25 @@
+<?php
+namespace App\Controllers;
+
+use App\Database;
+
+class UserController
+{
+    public static function register(): void
+    {
+        $data = json_decode(file_get_contents('php://input'), true);
+        if (!isset($data['name'], $data['email'], $data['role'])) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Invalid input']);
+            return;
+        }
+        $pdo = Database::getConnection();
+        $stmt = $pdo->prepare('INSERT INTO users (name, email, role) VALUES (:name, :email, :role)');
+        $stmt->execute([
+            ':name' => $data['name'],
+            ':email' => $data['email'],
+            ':role' => $data['role'],
+        ]);
+        echo json_encode(['id' => $pdo->lastInsertId()]);
+    }
+}

--- a/src/Database.php
+++ b/src/Database.php
@@ -1,0 +1,21 @@
+<?php
+namespace App;
+
+use PDO;
+
+class Database
+{
+    private static ?PDO $pdo = null;
+
+    public static function getConnection(): PDO
+    {
+        if (self::$pdo === null) {
+            $config = require __DIR__ . '/../config/database.php';
+            $username = $config['username'] ?? null;
+            $password = $config['password'] ?? null;
+            self::$pdo = new PDO($config['dsn'], $username, $password);
+            self::$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        }
+        return self::$pdo;
+    }
+}

--- a/src/Models/Job.php
+++ b/src/Models/Job.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Models;
+
+class Job
+{
+    public int $id;
+    public string $title;
+    public string $description;
+    public string $requiredSkills;
+}

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Models;
+
+class User
+{
+    public int $id;
+    public string $name;
+    public string $email;
+    public string $role; // 'seeker' or 'recruiter'
+}


### PR DESCRIPTION
## Summary
- add modern HTML, CSS, and JS interface
- update router to serve the new frontend
- document web UI usage in the README

## Testing
- `composer install`
- `php -l src/Database.php`
- `php -l scripts/migrate.php`
- `php -l src/Controllers/UserController.php`
- `php -l src/Controllers/JobController.php`
- `php -l src/Controllers/ApplicationController.php`
- `php -l src/Controllers/DocumentController.php`
- `php -l src/Controllers/MessageController.php`
- `php -l public/index.php`
- `php -l src/Models/User.php`
- `php -l src/Models/Job.php`

------
https://chatgpt.com/codex/tasks/task_e_687e7bf4bd2c8329a2fed2bc97b264fa